### PR TITLE
Route53のHostedZoneのTypeをPublicに修正

### DIFF
--- a/eks/files/eks-externaldns-deployment.yaml
+++ b/eks/files/eks-externaldns-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --domain-filter=qicoo.tokyo
         - --provider=aws
         - --policy=sync
-        - --aws-zone-type=private 
+        - --aws-zone-type=public
         - --registry=txt
         - --txt-owner-id=my-identifier   
         env:


### PR DESCRIPTION
ExternalDNSのDeploymentについて。Route53のHostedZoneのTypeをPublicに修正
