### PR TITLE
Arkでリストア対象のNamespaceを変更。PrometheusOperatorを導入するにあたり、Namespace名の変更が発生

### DIFF
--- a/vars/all.yml
+++ b/vars/all.yml
@@ -142,7 +142,7 @@ ARK:
   GC_SYNC_PERIOD: 30m
   SCHEDULE_SYNC_PERIOD: 1m
   RESTORE_ONLY_MODE: false
-  RESTORE_NAMESPACES: production,staging,kayenta-prometheus
+  RESTORE_NAMESPACES: production,staging,monitoring
 
 ## Slack Informing
 SLACK:


### PR DESCRIPTION
Arkでリストア対象のNamespaceを変更。PrometheusOperatorを導入するにあたり、Namespace名の変更が発生