### PR TITLE
Prometheusの公開ポートを9090に変更。Grafanaから接続するためには9090だと楽に接続できる

### DIFF
--- a/spinnaker/files/prometheus-service.yaml
+++ b/spinnaker/files/prometheus-service.yaml
@@ -9,7 +9,7 @@ spec:
   type: LoadBalancer
   ports:
   - name: web
-    port: 80
+    port: 9090
     targetPort: web
   selector:
     app: prometheus


### PR DESCRIPTION
Prometheusの公開ポートを9090に変更。Grafanaから接続するためには9090だと楽に接続できる