### PR TITLE
下げる時にrdsのスナップショットを取得しない

### DIFF
--- a/aws/files/cloudformation-rds-withroute53.yaml
+++ b/aws/files/cloudformation-rds-withroute53.yaml
@@ -59,7 +59,7 @@ Resources:
         - !Ref VPCSecurityGroups
       CopyTagsToSnapshot: true
       BackupRetentionPeriod: 7
-    DeletionPolicy: Snapshot
+    DeletionPolicy: Delete
   DatabaseDNSRecord:
     Type: "AWS::Route53::RecordSet"
     Properties:

--- a/bat/async-ansible-down.py
+++ b/bat/async-ansible-down.py
@@ -40,29 +40,31 @@ def async_ansible_down(loop):
     command01 = ansible_ctl + '/home/qicoo/qicoo-ansible/ark/create-heptio-backup.yml'
     command02 = '/home/qicoo/qicoo-ansible/bat/hal-backup.sh'
     command03 = '/home/qicoo/qicoo-ansible/bat/elb-all-down.sh'
+    command04 = '/home/qicoo/qicoo-ansible/bat/sg-all-down.sh'
     one =   sh_exec(command01) 
     two =   sh_exec(command02)
     three = sh_exec(command03)
+    four =  sh_exec(command04)
 
-    command04 = ansible_ctl + '/home/qicoo/qicoo-ansible/eks/delete-eks-env.yml'
-    command05 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-production.yml'
-    command06 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-staging.yml'
-    command07 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-development.yml'
-    command08 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-production.yml'
-    command09 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-staging.yml'
-    command10 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-development.yml'
-    commands = asyncio.gather(sh_coroutine(command04), \
-                              sh_coroutine(command05), \
+    command05 = ansible_ctl + '/home/qicoo/qicoo-ansible/eks/delete-eks-env.yml'
+    command06 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-production.yml'
+    command07 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-staging.yml'
+    command08 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-rds-development.yml'
+    command09 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-production.yml'
+    command10 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-staging.yml'
+    command11 = ansible_ctl + '/home/qicoo/qicoo-ansible/aws/delete-elasticache-development.yml'
+    commands = asyncio.gather(sh_coroutine(command05), \
                               sh_coroutine(command06), \
                               sh_coroutine(command07), \
                               sh_coroutine(command08), \
                               sh_coroutine(command09), \
-                              sh_coroutine(command10))
+                              sh_coroutine(command10), \
+                              sh_coroutine(command11))
 
-    four, five, six, seven, eight, nine, ten  = loop.run_until_complete(commands)
+    five, six, seven, eight, nine, ten, eleven  = loop.run_until_complete(commands)
     loop.close()
 
-    stdoutlist = [one, two, three, four, five, six, seven, eight, nine, ten]
+    stdoutlist = [one, two, three, four, five, six, seven, eight, nine, ten, eleven]
     with open(log_file_path,'w') as f:
         for stdout in stdoutlist:
             f.write(stdout)

--- a/bat/elb-all-down.sh
+++ b/bat/elb-all-down.sh
@@ -4,4 +4,5 @@ LB_LIST=(`aws elb describe-load-balancers | jq -r '.LoadBalancerDescriptions[].L
 for((i=0; i<${#LB_LIST[@]}; i++))
 do
   aws elb delete-load-balancer --load-balancer-name ${LB_LIST[i]}
+  echo "Delete the ELB, ${LB_LIST[i]}"
 done

--- a/bat/sg-all-down.sh
+++ b/bat/sg-all-down.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SG_LIST=`/home/qicoo/.local/bin/aws ec2 describe-security-groups`
+GROUP_ID_LIST=(`echo ${SG_LIST} | jq -r '.SecurityGroups[].GroupId'`)
+DESCRIPTION_LIST=(`echo ${SG_LIST} | jq -r '.SecurityGroups[].Description' | tr ' ' '$'`)
+
+for((i=0; i<${#DESCRIPTION_LIST[@]}; i++))
+do
+  if echo ${DESCRIPTION_LIST[i]} | tr '$' ' ' | grep 'Security group for Kubernetes ELB' >/dev/null 2>&1; then
+    /home/qicoo/.local/bin/aws ec2 delete-security-group --group-id ${GROUP_ID_LIST[i]}
+    echo "Delete the Security Group is Created by EKS, ${GROUP_ID_LIST[i]}"
+  fi
+done


### PR DESCRIPTION
一旦スナップショットを作成しないように設定しておく（限度量まで永遠にスナップショットができてしまう）。

